### PR TITLE
feat: Add sliding sidebar component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import { User, BookOpen, AppWindow, Gamepad2, Film } from "lucide-react";
+import React, { useState } from "react";
+import { User, BookOpen, AppWindow, Gamepad2, Film, Menu } from "lucide-react";
 import Navbar from "./components/Navbar";
+import Sidebar from "./components/Sidebar";
 import Hero from "./components/Hero";
 import Section from "./components/Section";
 
@@ -47,9 +48,24 @@ const sections = [
 
 function App() {
   const [activeSection, setActiveSection] = React.useState("hero");
+  const [isSidebarOpen, setSidebarOpen] = useState(false);
+
+  const toggleSidebar = () => {
+    setSidebarOpen(!isSidebarOpen);
+  };
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <Sidebar isOpen={isSidebarOpen} toggleSidebar={toggleSidebar} />
+
+      <button
+        onClick={toggleSidebar}
+        className="fixed top-4 left-4 z-50 p-2 bg-gray-700 text-white rounded-md hover:bg-gray-600 transition-colors"
+        aria-label="Toggle sidebar"
+      >
+        <Menu size={24} />
+      </button>
+
       <Navbar sections={sections} activeSection={activeSection} />
 
       <main>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Bot, SignIn } from 'lucide-react';
+
+interface SidebarProps {
+  isOpen: boolean;
+  toggleSidebar: () => void;
+}
+
+const Sidebar: React.FC<SidebarProps> = ({ isOpen, toggleSidebar }) => {
+  return (
+    <>
+      {/* Overlay to close sidebar on click */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 z-30 lg:hidden"
+          onClick={toggleSidebar}
+        ></div>
+      )}
+
+      <motion.div
+        initial={{ x: "-100%" }}
+        animate={{ x: isOpen ? "0%" : "-100%" }}
+        transition={{ type: "spring", stiffness: 300, damping: 30 }}
+        className="fixed top-0 left-0 bottom-0 w-64 bg-gray-800 text-white shadow-lg z-40 flex flex-col p-5"
+      >
+        {/* Top Icon */}
+        <div className="mb-10">
+          <Bot size={40} className="text-purple-400" />
+        </div>
+
+        {/* Sign In Button */}
+        <button
+          onClick={() => console.log("Sign in clicked")} // Replace with actual sign-in logic
+          className="flex items-center justify-center w-full p-2 mb-10 bg-purple-600 hover:bg-purple-700 rounded-lg text-white"
+        >
+          <SignIn size={20} className="mr-2" />
+          Sign In
+        </button>
+
+        {/* Middle Content Placeholder */}
+        <div className="flex-grow mb-10">
+          <p className="text-gray-400">Middle Content</p>
+        </div>
+
+        {/* Bottom Visitor Stats */}
+        <div className="mt-auto">
+          <p className="text-sm text-gray-400">Today's Visitors: 0</p>
+          <p className="text-sm text-gray-400">Total Visitors: 0</p>
+        </div>
+
+        {/* Optional: Close button inside the sidebar for mobile */}
+        <button
+            onClick={toggleSidebar}
+            className="lg:hidden absolute top-4 right-4 text-gray-300 hover:text-white"
+            aria-label="Close sidebar"
+        >
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+        </button>
+      </motion.div>
+    </>
+  );
+};
+
+export default Sidebar;


### PR DESCRIPTION
I've implemented a new sliding sidebar feature:

- It creates a new `Sidebar.tsx` component with Tailwind CSS and Framer Motion for animations.
- The sidebar is positioned on the left and slides in/out.
- Sidebar content includes:
    - A 'Bot' icon at the top.
    - A 'Sign in' button.
    - Placeholder for middle content.
    - Placeholders for 'Today's Visitors' and 'Total Visitors' counts at the bottom.
- I've integrated the sidebar into `App.tsx`:
    - Added state management for sidebar visibility.
    - Included a toggle button (Menu icon) fixed at the top-left of the viewport to open/close the sidebar.
- The sidebar overlays the main content.
- It includes an overlay and an internal close button for improved usability on smaller screens.
- I've ensured proper z-index management for the sidebar, toggle button, and existing Navbar.