### PR TITLE
feat: 초기 관리자 페이지 설정 및 접근 로직 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "framer-motion": "^11.0.8",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.6.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -2676,6 +2677,14 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4531,6 +4540,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "dependencies": {
+        "react-router": "7.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4691,6 +4736,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7181,6 +7231,11 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -8482,6 +8537,23 @@
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true
     },
+    "react-router": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "requires": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "requires": {
+        "react-router": "7.6.2"
+      }
+    },
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -8581,6 +8653,11 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
+    },
+    "set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "framer-motion": "^11.0.8",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.6.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react"; // Added useEffect
+import { Routes, Route } from "react-router-dom";
 import { User as LucideUser, BookOpen, AppWindow, Gamepad2, Film, Menu } from "lucide-react"; // Renamed User to LucideUser to avoid conflict
 import Navbar from "./components/Navbar";
 import Sidebar from "./components/Sidebar";
@@ -9,6 +10,11 @@ import SignUpModal from "./components/SignUpModal";
 import Hero from "./components/Hero";
 import Section from "./components/Section";
 import Footer from "./components/Footer"; // Import Footer
+import AdminPage from "./pages/AdminPage"; // Import the new AdminPage
+
+const ADMIN_EMAIL = "falltrip97@gmail.com";
+
+// Placeholder AdminPage component has been removed
 
 const sections = [
   {
@@ -57,11 +63,13 @@ function App() {
   const [isSignInModalOpen, setIsSignInModalOpen] = useState(false);
   const [isSignUpModalOpen, setIsSignUpModalOpen] = useState(false);
   const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
   const [loadingAuthState, setLoadingAuthState] = useState(true);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (user) => {
       setCurrentUser(user);
+      setIsAdmin(user?.email === ADMIN_EMAIL);
       setLoadingAuthState(false);
       // console.log("Auth state changed, user:", user);
       // If user is logged in, close modals, otherwise they might stay open if login happens while modal is up.
@@ -113,6 +121,7 @@ function App() {
         toggleSidebar={toggleSidebar}
         openSignInModal={openSignInModal}
         currentUser={currentUser}
+        isAdmin={isAdmin}
       />
 
       <Navbar
@@ -120,21 +129,33 @@ function App() {
         activeSection={activeSection}
         toggleSidebar={toggleSidebar}
         isSidebarOpen={isSidebarOpen}
+        currentUser={currentUser}
+        isAdmin={isAdmin}
       />
 
       <main>
-        <Hero />
-
-        {sections.map((section) => (
-          <Section
-            key={section.id}
-            id={section.id}
-            title={section.title}
-            description={section.description}
-            image={section.image}
-            Icon={section.icon}
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <>
+                <Hero />
+                {sections.map((section) => (
+                  <Section
+                    key={section.id}
+                    id={section.id}
+                    title={section.title}
+                    description={section.description}
+                    image={section.image}
+                    Icon={section.icon}
+                  />
+                ))}
+                <Footer />
+              </>
+            }
           />
-        ))}
+          <Route path="/admin" element={<AdminPage />} />
+        </Routes>
       </main>
 
       <SignInModal
@@ -147,8 +168,7 @@ function App() {
         onClose={closeSignUpModal}
         onSwitchToSignIn={switchToSignIn}
       />
-
-      <Footer /> {/* Add Footer component */}
+      {/* Footer is now part of the / route's element */}
     </div>
   );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { motion } from "framer-motion";
-import { Menu, Bot } from "lucide-react"; // Added Bot import
+import { Menu, Bot, Shield } from "lucide-react"; // Added Bot import
+import { Link } from "react-router-dom"; // Import Link
+
+import { User } from "firebase/auth";
 
 interface NavbarProps {
   sections: Array<{
@@ -11,9 +14,11 @@ interface NavbarProps {
   activeSection: string;
   toggleSidebar: () => void; // Added toggleSidebar
   isSidebarOpen: boolean;    // Added isSidebarOpen
+  currentUser?: User | null;
+  isAdmin?: boolean;
 }
 
-const Navbar = ({ sections, activeSection, toggleSidebar, isSidebarOpen }: NavbarProps) => { // Added props
+const Navbar = ({ sections, activeSection, toggleSidebar, isSidebarOpen, currentUser, isAdmin }: NavbarProps) => { // Added props
   return (
     <motion.nav
       initial={{ y: -100 }}
@@ -72,6 +77,21 @@ const Navbar = ({ sections, activeSection, toggleSidebar, isSidebarOpen }: Navba
               </motion.li>
             );
           })}
+          {/* Admin Page Button */}
+          {isAdmin && currentUser && (
+            <motion.li
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+            >
+              <Link
+                to="/admin"
+                className="flex items-center space-x-1 px-4 py-2 rounded-full bg-purple-600 hover:bg-purple-700 text-white transition-colors relative"
+              >
+                <Shield size={20} className="text-white" />
+                <span className="font-medium">Admin Page</span>
+              </Link>
+            </motion.li>
+          )}
         </ul>
       </div>
     </motion.nav>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,9 +9,10 @@ interface SidebarProps {
   toggleSidebar: () => void;
   openSignInModal: () => void;
   currentUser: User | null; // Updated type
+  isAdmin?: boolean;
 }
 
-const Sidebar: React.FC<SidebarProps> = ({ isOpen, toggleSidebar, openSignInModal, currentUser }) => {
+const Sidebar: React.FC<SidebarProps> = ({ isOpen, toggleSidebar, openSignInModal, currentUser, isAdmin }) => {
   return (
     <>
       {/* Overlay to close sidebar on click */}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import App from './App.tsx'
 import './index.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+const AdminPage: React.FC = () => {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h1>관리자 페이지</h1>
+      <p>이곳에서 콘텐츠를 관리할 수 있습니다.</p>
+
+      <div style={{ marginTop: '20px', marginBottom: '20px' }}>
+        {/* 콘텐츠 관리 버튼 UI 골격 */}
+        <button style={{ marginRight: '10px', padding: '8px 12px' }}>콘텐츠 추가</button>
+        <button style={{ marginRight: '10px', padding: '8px 12px' }}>콘텐츠 수정</button>
+        <button style={{ padding: '8px 12px' }}>콘텐츠 삭제</button>
+      </div>
+
+      <div style={{ marginTop: '20px', border: '1px solid #ccc', padding: '10px' }}>
+        <h2>등록된 콘텐츠 리스트 (예시)</h2>
+        {/* 실제 콘텐츠 리스트는 추후 구현 */}
+        <p>콘텐츠 목록이 여기에 표시됩니다.</p>
+      </div>
+
+      <div style={{ marginTop: '30px' }}>
+        <h2>Iframe으로 외부 페이지 연결 (예시)</h2>
+        <iframe
+          title="Admin Content Iframe"
+          style={{ width: '100%', height: 'calc(100vh - 400px)', border: '1px solid #ddd' }}
+          src="#" // 초기 src, 필요에 따라 변경
+        ></iframe>
+      </div>
+    </div>
+  );
+};
+
+export default AdminPage;


### PR DESCRIPTION
- `falltrip97@gmail.com` 계정을 관리자로 지정합니다.
- 관리자로 로그인 시 Navbar에 "Admin Page" 버튼을 표시합니다.
- "/admin" 경로로 접근 가능한 기본 관리자 페이지를 생성합니다.
  - 관리자 페이지에는 콘텐츠 관리 UI의 기본 골격과 iframe이 포함됩니다.
- react-router-dom을 설정하여 페이지 간 라우팅을 활성화합니다.